### PR TITLE
Puts back $GHC_PACKAGE_PATH back in place.

### DIFF
--- a/skeletons/activate
+++ b/skeletons/activate
@@ -92,6 +92,7 @@ export PACKAGE_DB_FOR_GHC_PKG=" --no-user-package-${PKG_DB_OPT_SUFFIX} $(replace
 export PACKAGE_DB_FOR_GHC=" -no-user-package-${PKG_DB_OPT_SUFFIX} $(replace_pkg -package-${PKG_DB_OPT_SUFFIX}=)"
 export PACKAGE_DB_FOR_GHC_MOD=" -g -no-user-package-${PKG_DB_OPT_SUFFIX} $(replace_pkg '-g -package-'${PKG_DB_OPT_SUFFIX}=)"
 
+export GHC_PACKAGE_PATH=$(cat <HSENV_DIR>/ghc_package_path_var)
 export PS1="(${HSENV_NAME})${PS1}"
 
 unset -v GHC_VERSION_OUTPUT

--- a/skeletons/cabal
+++ b/skeletons/cabal
@@ -1,5 +1,7 @@
 #!/bin/sh
 
+unset GHC_PACKAGE_PATH
+
 PATH_ELEMS="$(echo ${PATH} | tr -s ':' '\n')"
 
 ORIG_CABAL_BINARY=""


### PR DESCRIPTION
Disables it the cabal wrapper to avoid conflict with Cabal 1.16.

Note: The unset GHC_PACKAGE_PATH was already in place in deactivate_hsenv
