### PR TITLE
[unset-GHC_MODE-env-var] unsets the PACKAGE_DB_FOR_GHC_MOD

### DIFF
--- a/skeletons/activate
+++ b/skeletons/activate
@@ -40,6 +40,7 @@ deactivate_hsenv() {
     unset -v PACKAGE_DB_FOR_CABAL
     unset -v PACKAGE_DB_FOR_GHC_PKG
     unset -v PACKAGE_DB_FOR_GHC
+    unset -v PACKAGE_DB_FOR_GHC_MOD
     unset -v HSENV
     unset -v HSENV_NAME
     unset -v HASKELL_PACKAGE_SANDBOX


### PR DESCRIPTION
I was playing around with HSENV and Haskell, and noticed this one variable wasn't being cleaned up when the environment is deactivated.
