### PR TITLE
Fixes #23, second attempt :)

### DIFF
--- a/hsenv.cabal
+++ b/hsenv.cabal
@@ -112,6 +112,8 @@ Executable hsenv
                , split >= 0.1.4 && < 0.3
                , safe >= 0.3 && < 0.4
                , unix >= 2.0 && < 2.7
+               , http-streams >= 0.6.0.2 && <= 0.7
+               , io-streams >= 1.1.0.0 && <= 1.2.0.0
 
   Other-modules: Util.Cabal
                , Util.Args

--- a/src/Actions.hs
+++ b/src/Actions.hs
@@ -22,6 +22,10 @@ import Safe (lastMay)
 import Data.List (intercalate)
 import Data.Maybe (fromMaybe, isJust)
 
+import Network.Http.Client
+import qualified Data.ByteString.Char8 as C8
+import qualified System.IO.Streams as S
+
 import HsenvMonad
 import Types
 import Paths
@@ -313,13 +317,21 @@ installExternalGhc tarballPath = do
     liftIO $ removeDirectoryRecursive tmpGhcDir
     return ()
 
+-- Download a file over HTTP using streams, so it
+-- has constant memory allocation.
+downloadFile :: URL -> FilePath -> Hsenv ()
+downloadFile url name = liftIO $ get url $ \response inStream -> 
+    case getStatusCode response of
+      200 -> S.withFileAsOutput name (S.connect inStream)
+      code -> error $ "Failed to download " ++ name ++ ": http response returned " ++ show code
+
 installRemoteGhc :: String -> Hsenv ()
 installRemoteGhc url = do
     dirStructure <- hseDirStructure
     downloadDir <- liftIO $ createTemporaryDirectory (hsEnv dirStructure) "ghc-download"
     let tarball = downloadDir </> "tarball"
     debug $ "Downloading GHC from " ++ url
-    _ <- indentMessages $ outsideProcess' "curl" ["-fL", "--retry", "2", url, "-o", tarball]
+    downloadFile (C8.pack url) tarball
     installExternalGhc tarball
     liftIO $ removeDirectoryRecursive downloadDir
     return ()


### PR DESCRIPTION
Ok, it should be _almost_ there.

The only warty thing is, as you might notice, is that we call `error` when we fail. I've tried to stick to the project convention , doing something like:

```
case code -> throwError $ HsenvException $ bla bla bla
```

But I got an error which puzzles me:

```
src/Actions.hs:326:15:
    Couldn't match type `GHC.IO.Exception.IOException'
                  with `HsenvException'
    When using functional dependencies to combine
      Control.Monad.Error.Class.MonadError
        GHC.IO.Exception.IOException IO,
        arising from the dependency `m -> e'
        in the instance declaration in `Control.Monad.Error.Class'
      Control.Monad.Error.Class.MonadError HsenvException IO,
        arising from a use of `throwError' at src/Actions.hs:326:15-24
    In the expression: throwError
    In the expression:
      throwError
      $ HsenvException
        $ "Failed to download "
          ++ name ++ ": http response returned " ++ show code
```

I suspect it's because we are lifting the whole computation from the IO, but I might be wrong. Insight and fixes are welcome. One quick to do would be to use `throw` instead of `throwError`, where the former lives inside `Control.Exception`. To do that, we also need to add an instance of `Exception` to `HsenvException`, which is a one liner:

```
instance Exception HsenvException
```

A.
