### PR TITLE
Making downloadFile multiplatform

### DIFF
--- a/hsenv.cabal
+++ b/hsenv.cabal
@@ -113,6 +113,7 @@ Executable hsenv
                , safe >= 0.3 && < 0.4
                , unix >= 2.0 && < 2.7
                , http-streams >= 0.6.0.2 && <= 0.7
+               , network >= 2.4.0.0 && <= 2.5.0.0
                , io-streams >= 1.1.0.0 && <= 1.2.0.0
 
   Other-modules: Util.Cabal

--- a/src/Actions.hs
+++ b/src/Actions.hs
@@ -23,6 +23,7 @@ import Data.List (intercalate)
 import Data.Maybe (fromMaybe, isJust)
 
 import Network.Http.Client
+import Network.Socket (withSocketsDo)
 import qualified Data.ByteString.Char8 as C8
 import qualified System.IO.Streams as S
 
@@ -321,7 +322,7 @@ installExternalGhc tarballPath = do
 -- has constant memory allocation.
 downloadFile :: URL -> FilePath -> Hsenv ()
 downloadFile url name = do
-  m_ex <- liftIO $ get url $ \response inStream ->
+  m_ex <- liftIO $ withSocketsDo $ get url $ \response inStream ->
     case getStatusCode response of
       200 -> S.withFileAsOutput name (S.connect inStream) >> return Nothing
       code -> return $ Just $ HsenvException $


### PR DESCRIPTION
Two days ago, I've posted on Reddit the snippet I've used to download a file from internet with http-streams, along
with a version featuring a funky progress bar: 

http://www.reddit.com/r/haskell/comments/1iihvg/neat_trick_downloading_a_file_over_http_using/

One interesting thing someone suggested is that that function could have been made cross platform simply adding `withSocketsDo`, so this is a patch implementing this.
