### PR TITLE
add ghc-7.8 support  by relaxing cabal constraint

### DIFF
--- a/hsenv.cabal
+++ b/hsenv.cabal
@@ -131,17 +131,17 @@ Executable hsenv
 
   Ghc-options: -threaded -Wall
 
-  Build-depends: base >= 4.2.0.0 && < 4.7
-               , process >= 1.0.1.2 && < 1.2
+  Build-depends: base >= 4.2.0.0 && < 4.8
+               , process >= 1.0.1.2 && < 1.3
                , filepath >= 1.1.0.3 && < 1.4
                , directory >= 1.0.1.0 && < 1.3
-               , Cabal >= 1.8.0.6 && < 1.17
+               , Cabal >= 1.8.0.6 && < 1.19
                , mtl >= 1.1.0.2 && < 2.2
                , bytestring >= 0.9.1.7 && < 0.11
                , file-embed >= 0.0.4.1 && < 0.1
                , split >= 0.1.4 && < 0.3
                , safe >= 0.3 && < 0.4
-               , unix >= 2.0 && < 2.7
+               , unix >= 2.0 && < 2.8
                , http-streams >= 0.6.0.2 && <= 0.7
                , io-streams >= 1.1.0.0 && <= 1.2.0.0
 


### PR DESCRIPTION
As commented on https://github.com/tmhedberg/hsenv/issues/40, I've tried to build hsenv-0.4 with ghc-7.8.2.
ghc-7.8.2 has new version of `base`, `Cabal`, `process` and `unix` packages.
These new packages causes unsatisfy dependencies.
