### PR TITLE
Remove redundant -E option for grep

### DIFF
--- a/skeletons/cabal
+++ b/skeletons/cabal
@@ -32,7 +32,7 @@ fi
 
 CABAL_BUILDABLE_COMMANDS="build clean configure copy haddock hscolour install register sdist test upgrade"
 
-CABAL_COMMAND="$(echo ${@} | tr -s ' ' '\n' | grep -E '[a-z]' | grep -Ev '^-'  | head -n 1)"
+CABAL_COMMAND="$(echo ${@} | tr -s ' ' '\n' | grep '[a-z]' | grep -v '^-'  | head -n 1)"
 
 for CABAL_BUILDABLE_COMMAND in ${CABAL_BUILDABLE_COMMANDS}; do
     if [ "${CABAL_BUILDABLE_COMMAND}" = "${CABAL_COMMAND}" ]; then


### PR DESCRIPTION
Solaris11's default grep doesn't have -E option. Also the change is tested on https://github.com/saturday06/hsenv.sh/commit/0b0b0a24802af73d413811c931a1e34a0fab8b82 .
